### PR TITLE
Add DeleteSection method for Init class

### DIFF
--- a/Config/Ini.cs
+++ b/Config/Ini.cs
@@ -140,6 +140,20 @@ namespace Multipetros.Config{
 				}
 			}
 		}
+
+        	// Removes section from file
+	        public void DeleteSection(string section)
+	        {
+	            if (sections.ContainsKey(section))
+	            {
+	                sections.Remove(section);
+	
+	                if (autosave)
+	                {
+	                    Save();
+	                }
+	            }
+	        }
 		
 		/// <summary>
 		/// Store properties to file


### PR DESCRIPTION
It is functionally equivalent to WritePrivateProfileString(section, null, null, filepath) call on Windows platform. This method will be useful on .Net Core or in any other cross-platform .Net implementation.
